### PR TITLE
added support for csproj parsing

### DIFF
--- a/pkg/nuget/csproj/parse.go
+++ b/pkg/nuget/csproj/parse.go
@@ -1,0 +1,68 @@
+package csproj
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+	"github.com/aquasecurity/go-dep-parser/pkg/utils"
+)
+
+type Parser struct{}
+
+func NewParser() types.Parser {
+	return &Parser{}
+}
+
+func (p *Parser) Parse(r dio.ReadSeekerAt) ([]types.Library, []types.Dependency, error) {
+	var cfgData csProject
+	if err := xml.NewDecoder(r).Decode(&cfgData); err != nil {
+		return nil, nil, xerrors.Errorf("failed to decode .csproj file: %w", err)
+	}
+
+	libs := make([]types.Library, 0)
+	for _, pkg := range cfgData.Packages {
+		if pkg.Include == "" || isDevDependency(pkg) {
+			continue
+		}
+
+		var versionNotFloating = strings.TrimRight(pkg.Version, ".*")
+
+		lib := types.Library{
+			Name:    pkg.Include,
+			Version: versionNotFloating,
+		}
+
+		libs = append(libs, lib)
+	}
+
+	return utils.UniqueLibraries(libs), nil, nil
+}
+
+func isDevDependency(pkg packageReference) bool {
+	var privateAssets = tagOrAttribute(pkg.PrivateAssetsTag, pkg.PrivateAssetsAttr)
+	var excludeAssets = tagOrAttribute(pkg.ExcludeAssetsTag, pkg.ExcludeAssetsAttr)
+	return assetListContains(privateAssets, "all") || assetListContains(excludeAssets, "all") || assetListContains(excludeAssets, "runtime")
+}
+
+func assetListContains(assets []string, needle string) bool {
+	for _, v := range assets {
+		if strings.EqualFold(v, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func tagOrAttribute(tag string, attr string) []string {
+	var strvalue = ""
+	if tag != "" {
+		strvalue = tag
+	} else {
+		strvalue = attr
+	}
+	return strings.Split(strvalue, ";")
+}

--- a/pkg/nuget/csproj/parse_test.go
+++ b/pkg/nuget/csproj/parse_test.go
@@ -1,0 +1,64 @@
+package csproj_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/go-dep-parser/pkg/nuget/csproj"
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name      string // Test input file
+		inputFile string
+		want      []types.Library
+		wantErr   string
+	}{
+		{
+			name:      "csproj",
+			inputFile: "testdata/packages.csproj",
+			want: []types.Library{
+				{Name: "Newtonsoft.Json", Version: "6.0.4"},
+				{Name: "Microsoft.AspNet.WebApi", Version: "5.2.2"},
+				{Name: "Floating.Version", Version: "1.2"},
+			},
+		},
+		{
+			name:      "with development dependency",
+			inputFile: "testdata/dev_dependency.csproj",
+			want: []types.Library{
+				{Name: "PrivateAssets.Tag.None", Version: "1.0.0"},
+				{Name: "PrivateAssets.Conflicting.Tag.Attribute", Version: "1.0.0"},
+				{Name: "ExcludeAssets.Tag.ContentFiles", Version: "1.0.0"},
+				{Name: "ExcludeAssets.Tag.None", Version: "1.0.0"},
+				{Name: "ExcludeAssets.Conflicting.Tag.Attribute", Version: "1.0.0"},
+				{Name: "Newtonsoft.Json", Version: "8.0.3"},
+			},
+		},
+		{
+			name:      "sad path",
+			inputFile: "testdata/malformed_xml.csproj",
+			wantErr:   "failed to decode .csproj file: XML syntax error on line 10: unexpected EOF",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := os.Open(tt.inputFile)
+			require.NoError(t, err)
+
+			got, _, err := csproj.NewParser().Parse(f)
+			if tt.wantErr != "" {
+				require.NotNil(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/nuget/csproj/testdata/dev_dependency.csproj
+++ b/pkg/nuget/csproj/testdata/dev_dependency.csproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <TargetFramework>net46</TargetFramework>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- PrivateAssets=all indicates a development dependency, and we exclude those -->
+        <PackageReference Include="PrivateAssets.Tag.All" Version="1.0.0">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="PrivateAssets.Tag.None" Version="1.0.0">
+            <PrivateAssets>none</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="PrivateAssets.Attribute.All" Version="1.0.0" PrivateAssets="All" />
+        <PackageReference Include="PrivateAssets.Conflicting.Tag.Attribute" Version="1.0.0"
+            PrivateAssets="All">
+            <PrivateAssets>None</PrivateAssets>
+        </PackageReference>
+
+        <!-- ExcludeAssets=all / runtime indicates a compile-time dependency, and we exclude those -->
+        <PackageReference Include="ExcludeAssets.Tag.All" Version="1.0.0">
+            <ExcludeAssets>all</ExcludeAssets>
+        </PackageReference>
+        <PackageReference Include="ExcludeAssets.Tag.Runtime" Version="1.0.0">
+            <ExcludeAssets>runtime</ExcludeAssets>
+        </PackageReference>
+        <PackageReference Include="ExcludeAssets.Tag.RuntimeAndMore" Version="1.0.0">
+            <ExcludeAssets>contentFiles;runtime;native</ExcludeAssets>
+        </PackageReference>
+        <PackageReference Include="ExcludeAssets.Tag.ContentFiles" Version="1.0.0">
+            <ExcludeAssets>contentFiles</ExcludeAssets>
+        </PackageReference>
+        <PackageReference Include="ExcludeAssets.Tag.None" Version="1.0.0">
+            <ExcludeAssets>none</ExcludeAssets>
+        </PackageReference>
+        <PackageReference Include="ExcludeAssets.Attribute.All" Version="1.0.0" ExcludeAssets="All" />
+        <PackageReference Include="ExcludeAssets.Conflicting.Tag.Attribute" Version="1.0.0"
+            ExcludeAssets="All">
+            <ExcludeAssets>None</ExcludeAssets>
+        </PackageReference>
+
+        <!-- Normal dependency -->
+        <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
+    </ItemGroup>
+</Project>

--- a/pkg/nuget/csproj/testdata/malformed_xml.csproj
+++ b/pkg/nuget/csproj/testdata/malformed_xml.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+</PropertyGroup>
+<ItemGroup>
+<PackageReference Include="Microsoft.Net.Compilers" Version="1.0.0">
+    <PrivateAssets>all</PrivateAssets>
+</PackageReference>
+<PackageReference Include="Newtonsoft.Json" Version="8.0.3" />

--- a/pkg/nuget/csproj/testdata/packages.csproj
+++ b/pkg/nuget/csproj/testdata/packages.csproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <TargetFramework>net45</TargetFramework>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- other ItemGroup elements can lack PackageReference elements -->
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="6.0.4" />
+        <PackageReference Include="Floating.Version" Version="1.2.*" />
+    </ItemGroup>
+    <ItemGroup>
+        <!-- other ItemGroup elements can lack PackageReference elements -->
+    </ItemGroup>
+</Project>

--- a/pkg/nuget/csproj/types.go
+++ b/pkg/nuget/csproj/types.go
@@ -1,0 +1,18 @@
+package csproj
+
+import "encoding/xml"
+
+type packageReference struct {
+	XMLName           xml.Name `xml:"PackageReference"`
+	Version           string   `xml:"Version,attr"`
+	Include           string   `xml:"Include,attr"`
+	PrivateAssetsTag  string   `xml:"PrivateAssets"`
+	PrivateAssetsAttr string   `xml:"PrivateAssets,attr"`
+	ExcludeAssetsTag  string   `xml:"ExcludeAssets"`
+	ExcludeAssetsAttr string   `xml:"ExcludeAssets,attr"`
+}
+
+type csProject struct {
+	XMLName  xml.Name           `xml:"Project"`
+	Packages []packageReference `xml:"ItemGroup>PackageReference"`
+}


### PR DESCRIPTION
## Description
This PR adds support for parsing csproject file in the dotnet project.

## Potential Issue
- This parser may not return the exact version of the dependancy since the parser is based of csproj file.
- Solution: To avoid such issue we can use the lock files as described below.

## Projects with Lock files
Lock file provides constant versioning for the dependancies present. To generate a lock file,
- Add the following options to your csproj file.
  ```xml
  <PropertyGroup>
    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
  </PropertyGroup>
  ```
- Once this configuration is added, run `dotnet restore` - this will generate a `package.lock.json` file in your repo.

Reference: https://devblogs.microsoft.com/nuget/enable-repeatable-package-restores-using-a-lock-file/