### PR TITLE
feature: csharp(nuget) - props file support added

### DIFF
--- a/pkg/nuget/packagesprops/parse.go
+++ b/pkg/nuget/packagesprops/parse.go
@@ -1,0 +1,85 @@
+package packagesprops
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"golang.org/x/xerrors"
+
+	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	ftypes "github.com/aquasecurity/go-dep-parser/pkg/types"
+	"github.com/aquasecurity/go-dep-parser/pkg/utils"
+)
+
+type Pkg struct {
+	Version            string `xml:"Version,attr"`
+	UpdatePackageName  string `xml:"Update,attr"`
+	IncludePackageName string `xml:"Include,attr"`
+}
+
+// https://github.com/dotnet/roslyn-tools/blob/b4c5220f5dfc4278847b6d38eff91cc1188f8066/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs#L150
+type itemGroup struct {
+	PackageReferenceEntry []Pkg `xml:"PackageReference"`
+	PackageVersionEntry   []Pkg `xml:"PackageVersion"`
+}
+
+type project struct {
+	XMLName    xml.Name    `xml:"Project"`
+	ItemGroups []itemGroup `xml:"ItemGroup"`
+}
+
+type Parser struct{}
+
+func NewParser() *Parser {
+	return &Parser{}
+}
+
+func (p Pkg) Package() ftypes.Library {
+	// Update attribute is considered legacy, so preferring Include
+	name := p.UpdatePackageName
+	if p.IncludePackageName != "" {
+		name = p.IncludePackageName
+	}
+
+	name = strings.TrimSpace(name)
+	version := strings.TrimSpace(p.Version)
+	return ftypes.Library{
+		ID:      utils.ID(ftypes.NuGet, name, version),
+		Name:    name,
+		Version: version,
+	}
+}
+
+func shouldSkipPkg(pkg ftypes.Library) bool {
+	if pkg.Name == "" || pkg.Version == "" {
+		return true
+	}
+	// *packages.props files don't contain variable resolution information.
+	// So we need to skip them.
+	if isVariable(pkg.Name) || isVariable(pkg.Version) {
+		return true
+	}
+	return false
+}
+
+func isVariable(s string) bool {
+	return strings.HasPrefix(s, "$(") && strings.HasSuffix(s, ")")
+}
+
+func (p *Parser) Parse(r dio.ReadSeekerAt) ([]ftypes.Library, []ftypes.Dependency, error) {
+	var configData project
+	if err := xml.NewDecoder(r).Decode(&configData); err != nil {
+		return nil, nil, xerrors.Errorf("failed to decode '*.packages.props' file: %w", err)
+	}
+
+	var pkgs []ftypes.Library
+	for _, item := range configData.ItemGroups {
+		for _, pkg := range append(item.PackageReferenceEntry, item.PackageVersionEntry...) {
+			pkg := pkg.Package()
+			if !shouldSkipPkg(pkg) {
+				pkgs = append(pkgs, pkg)
+			}
+		}
+	}
+	return utils.UniqueLibraries(pkgs), nil, nil
+}

--- a/pkg/nuget/packagesprops/parse_test.go
+++ b/pkg/nuget/packagesprops/parse_test.go
@@ -1,0 +1,82 @@
+package packagesprops_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	config "github.com/aquasecurity/go-dep-parser/pkg/nuget/packagesprops"
+	ftypes "github.com/aquasecurity/go-dep-parser/pkg/types"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name      string // Test input file
+		inputFile string
+		want      []ftypes.Library
+		wantErr   string
+	}{
+		{
+			name:      "PackagesProps",
+			inputFile: "testdata/packages.props",
+			want: []ftypes.Library{
+				{Name: "Microsoft.Extensions.Configuration", Version: "2.1.1", ID: "Microsoft.Extensions.Configuration@2.1.1"},
+				{Name: "Microsoft.Extensions.DependencyInjection.Abstractions", Version: "2.2.1", ID: "Microsoft.Extensions.DependencyInjection.Abstractions@2.2.1"},
+				{Name: "Microsoft.Extensions.Http", Version: "3.2.1", ID: "Microsoft.Extensions.Http@3.2.1"},
+			},
+		},
+		{
+			name:      "DirectoryPackagesProps",
+			inputFile: "testdata/Directory.Packages.props",
+			want: []ftypes.Library{
+				{Name: "PackageOne", Version: "6.2.3", ID: "PackageOne@6.2.3"},
+				{Name: "PackageTwo", Version: "6.0.0", ID: "PackageTwo@6.0.0"},
+				{Name: "PackageThree", Version: "2.4.1", ID: "PackageThree@2.4.1"},
+			},
+		},
+		{
+			name:      "SeveralItemGroupElements",
+			inputFile: "testdata/several_item_groups",
+			want: []ftypes.Library{
+				{Name: "PackageOne", Version: "6.2.3", ID: "PackageOne@6.2.3"},
+				{Name: "PackageTwo", Version: "6.0.0", ID: "PackageTwo@6.0.0"},
+				{Name: "PackageThree", Version: "2.4.1", ID: "PackageThree@2.4.1"},
+			},
+		},
+		{
+			name:      "VariablesAsNamesOrVersion",
+			inputFile: "testdata/variables_and_empty",
+			want: []ftypes.Library{
+				{Name: "PackageFour", Version: "2.4.1", ID: "PackageFour@2.4.1"},
+			},
+		},
+		{
+			name:      "NoItemGroupInXMLStructure",
+			inputFile: "testdata/no_item_group.props",
+			want:      []ftypes.Library(nil),
+		},
+		{
+			name:      "NoProject",
+			inputFile: "testdata/no_project.props",
+			wantErr:   "failed to decode '*.packages.props' file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := os.Open(tt.inputFile)
+			require.NoError(t, err)
+
+			got, _, err := config.NewParser().Parse(f)
+			if tt.wantErr != "" {
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/nuget/packagesprops/parse_test.go
+++ b/pkg/nuget/packagesprops/parse_test.go
@@ -32,8 +32,8 @@ func TestParse(t *testing.T) {
 			inputFile: "testdata/Directory.Packages.props",
 			want: []ftypes.Library{
 				{Name: "PackageOne", Version: "6.2.3", ID: "PackageOne@6.2.3"},
-				{Name: "PackageTwo", Version: "6.0.0", ID: "PackageTwo@6.0.0"},
 				{Name: "PackageThree", Version: "2.4.1", ID: "PackageThree@2.4.1"},
+				{Name: "PackageTwo", Version: "6.0.0", ID: "PackageTwo@6.0.0"},
 			},
 		},
 		{
@@ -41,8 +41,8 @@ func TestParse(t *testing.T) {
 			inputFile: "testdata/several_item_groups",
 			want: []ftypes.Library{
 				{Name: "PackageOne", Version: "6.2.3", ID: "PackageOne@6.2.3"},
-				{Name: "PackageTwo", Version: "6.0.0", ID: "PackageTwo@6.0.0"},
 				{Name: "PackageThree", Version: "2.4.1", ID: "PackageThree@2.4.1"},
+				{Name: "PackageTwo", Version: "6.0.0", ID: "PackageTwo@6.0.0"},
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestParse(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			assert.ElementsMatch(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/nuget/packagesprops/testdata/Directory.Packages.props
+++ b/pkg/nuget/packagesprops/testdata/Directory.Packages.props
@@ -1,0 +1,7 @@
+<Project>
+    <ItemGroup>
+        <PackageReference Include="PackageOne" Version=" 6.2.3" />
+        <PackageReference Include="PackageTwo" Version="6.0.0" />
+        <PackageReference Include="PackageThree " Version="2.4.1" />
+    </ItemGroup>
+</Project>

--- a/pkg/nuget/packagesprops/testdata/no_item_group.props
+++ b/pkg/nuget/packagesprops/testdata/no_item_group.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+
+    <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.1" />
+    <PackageReference Update="Microsoft.Extensions.Http" Version="3.2.1" />
+    <PackageReference WrongAttribute="Package1" Version="3.2.1" />
+    <WrongEntry Update="Package2" Version="3.2.1" />
+    <PackageReference Update="Package3" />
+
+</Project>

--- a/pkg/nuget/packagesprops/testdata/no_project.props
+++ b/pkg/nuget/packagesprops/testdata/no_project.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ItemGroup Label="Microsoft Nugets">
+    <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.1" />
+    <PackageReference Update="Microsoft.Extensions.Http" Version="3.2.1" />
+    <PackageReference WrongAttribute="Package1" Version="3.2.1" />
+    <WrongEntry Update="Package2" Version="3.2.1" />
+    <PackageReference Update="Package3" />
+</ItemGroup>

--- a/pkg/nuget/packagesprops/testdata/packages.props
+++ b/pkg/nuget/packagesprops/testdata/packages.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+  <ItemGroup Label="Microsoft Nugets">
+    <PackageReference Update="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.1" />
+    <PackageReference Update="Microsoft.Extensions.Http" Version="3.2.1" />
+    <PackageReference WrongAttribute="Package1" Version="3.2.1" />
+    <WrongEntry Update="Package2" Version="3.2.1" />
+    <PackageReference Update="Package3" />
+  </ItemGroup>
+</Project>

--- a/pkg/nuget/packagesprops/testdata/several_item_groups
+++ b/pkg/nuget/packagesprops/testdata/several_item_groups
@@ -1,0 +1,10 @@
+<Project>
+    <ItemGroup>
+        <PackageReference Include="PackageOne" Version="6.2.3" />
+        <PackageReference Include="PackageTwo" Version="6.0.0" />
+        
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="PackageThree" Version="2.4.1" />
+    </ItemGroup>
+</Project>

--- a/pkg/nuget/packagesprops/testdata/variables_and_empty
+++ b/pkg/nuget/packagesprops/testdata/variables_and_empty
@@ -1,0 +1,9 @@
+<Project>
+    <ItemGroup>
+        <PackageReference Include="PackageOne" Version="$(Variable1)" />
+        <PackageReference Include="$(variable2)" Version="6.0.0" />
+        <PackageReference Include="" Version="2.4.1" />
+        <PackageReference Include="package" Version="" />
+        <PackageReference Include="PackageFour" Version="2.4.1" />
+    </ItemGroup>
+</Project>

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -4,6 +4,54 @@ import (
 	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
 )
 
+type (
+	// TargetType represents the type of target
+	TargetType string
+
+	// LangType is an alias of TargetType for programming languages
+	LangType = TargetType
+)
+
+const (
+	Bundler       LangType = "bundler"
+	GemSpec       LangType = "gemspec"
+	Cargo         LangType = "cargo"
+	Composer      LangType = "composer"
+	Npm           LangType = "npm"
+	NuGet         LangType = "nuget"
+	DotNetCore    LangType = "dotnet-core"
+	PackagesProps LangType = "packages-props"
+	Pip           LangType = "pip"
+	Pipenv        LangType = "pipenv"
+	Poetry        LangType = "poetry"
+	CondaPkg      LangType = "conda-pkg"
+	CondaEnv      LangType = "conda-environment"
+	PythonPkg     LangType = "python-pkg"
+	NodePkg       LangType = "node-pkg"
+	Yarn          LangType = "yarn"
+	Pnpm          LangType = "pnpm"
+	Jar           LangType = "jar"
+	Pom           LangType = "pom"
+	Gradle        LangType = "gradle"
+	GoBinary      LangType = "gobinary"
+	GoModule      LangType = "gomod"
+	JavaScript    LangType = "javascript"
+	RustBinary    LangType = "rustbinary"
+	Conan         LangType = "conan"
+	Cocoapods     LangType = "cocoapods"
+	Swift         LangType = "swift"
+	Pub           LangType = "pub"
+	Hex           LangType = "hex"
+	Bitnami       LangType = "bitnami"
+
+	K8sUpstream LangType = "kubernetes"
+	EKS         LangType = "eks" // Amazon Elastic Kubernetes Service
+	GKE         LangType = "gke" // Google Kubernetes Engine
+	AKS         LangType = "aks" // Azure Kubernetes Service
+	RKE         LangType = "rke" // Rancher Kubernetes Engine
+	OCP         LangType = "ocp" // Red Hat OpenShift Container Platform
+)
+
 type Library struct {
 	ID                 string `json:",omitempty"`
 	Name               string

--- a/pkg/utils/id.go
+++ b/pkg/utils/id.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/aquasecurity/go-dep-parser/pkg/types"
+)
+
+// ID returns a unique ID for the given library.
+// The package ID is used to construct the dependency graph.
+// The separator is different for each language type.
+func ID(ltype types.LangType, name, version string) string {
+	if version == "" {
+		return name
+	}
+
+	sep := "@"
+	switch ltype {
+	case types.Conan:
+		sep = "/"
+	case types.GoModule, types.GoBinary:
+		// Return a module ID according the Go way.
+		// Format: <module_name>@v<module_version>
+		// e.g. github.com/aquasecurity/go-dep-parser@v0.0.0-20230130190635-5e31092b0621
+		if !strings.HasPrefix(version, "v") {
+			version = "v" + version
+		}
+	case types.Jar, types.Pom, types.Gradle:
+		sep = ":"
+	}
+	return name + sep + version
+}


### PR DESCRIPTION
## Description
This PR adds support for parsing **.props** file in the dotnet(nuget) project. 

**Note**: We have imported code from https://github.com/aquasecurity/trivy/tree/main/pkg/dependency/parser/nuget. For future we have imported programming language type and ID. To keep this code consistent with original author. 

Reference:
https://devblogs.microsoft.com/nuget/introducing-central-package-management/